### PR TITLE
Atlanta 2023 - BI SQL Saturday - updates on registration and precons

### DIFF
--- a/_data/events/SQLSat1042.yml
+++ b/_data/events/SQLSat1042.yml
@@ -17,10 +17,19 @@ eventlocation: |
 eventlocationurl: 
 
 officialwebsite: 
-registrationurl: 
+registrationurl: https://www.eventbrite.com/e/sql-saturday-atlanta-2023-bi-data-analytics-edition-1042-tickets-482105690097
 capacity: 
 googlemapurl: "https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13218.875349195547!2d-84.2992935!3d34.0767211!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x18e450a972d9c243!2sInnovation%20Academy!5e0!3m2!1sen!2sus!4v1666817573547!5m2!1sen!2sus"
-precons: false
+precons: true
+precondetail: |
+    <p>There will be three pre conference sessions available on Friday, February 24, 2022. These are:</p>
+    <p><b>** Early bird price - $125 through January 15 , 2023 ** Regular Price: $150</b></p>
+    <p><b>Note: Precon Location: Microsoft Office Alpharetta - 8000 Avalon Blvd, Suite 900, Alpharetta GA 30009</b></p>
+    <ul>
+      <li><a href="https://www.eventbrite.com/e/power-bi-the-day-after-dashboard-in-a-day-tickets-488620927347" target="_blank" rel="noopener noreferrer">Power BI : The Day after Dashboard in a Day</a> by Patrick Leblanc & Alex Powers</li>
+      <li><a href="https://www.eventbrite.com/e/a-day-of-azure-data-factory-tickets-488853242207" target="_blank" rel="noopener noreferrer">ADF : A Day of Azure Data Factory</a> by Andy Leonard</li>
+      <li><a href="https://www.eventbrite.com/e/power-bi-building-impactful-reports-tickets-488862058577" target="_blank" rel="noopener noreferrer">Power BI : Building Impactful Reports</a> by Reid Havens, MVP</li>
+    </ul>
 scheduleurl: 
 scheduletimezone: Eastern Daylight Savings time UTC -5
 lunchcost: 


### PR DESCRIPTION
Updated the links to the registration for Atlanta SQL Saturday 1042.  Also added the information on precons.