### PR TITLE
Austin - Update Event Link

### DIFF
--- a/_data/events/SQLSat1043.yml
+++ b/_data/events/SQLSat1043.yml
@@ -18,7 +18,7 @@ eventlocation: |
 eventlocationurl: https://www.google.com/maps/place/Microsoft+Corporation/@30.400579,-97.7368883,17z/data=!4m12!1m6!3m5!1s0x8644cc7b124596ad:0x1a540c719cf65065!2sMicrosoft+Corporation!8m2!3d30.4005744!4d-97.7346943!3m4!1s0x8644cc7b124596ad:0x1a540c719cf65065!8m2!3d30.4005744!4d-97.7346943
 
 officialwebsite: 
-registrationurl: https://www.eventbrite.com/e/sql-saturday-austin-2023-tickets-470795511047
+registrationurl: https://www.eventbrite.com/cc/sql-saturday-austin-tx-1043-1532229
 capacity: 150
 googlemapurl: "https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13765.010392513923!2d-97.7346943!3d30.4005744!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x1a540c719cf65065!2sMicrosoft%20Corporation!5e0!3m2!1sen!2sus!4v1671141951795!5m2!1sen!2sus"
 precons: true


### PR DESCRIPTION
SQLSaturdayAustin - Update the Event Link to Eventbrite Collection so everyone instantly sees both the pre-con and the event.