### PR TITLE
Update SQLSat1056.yml

### DIFF
--- a/_data/events/SQLSat1056.yml
+++ b/_data/events/SQLSat1056.yml
@@ -31,10 +31,10 @@ eventcountdown: false
 
 countdownscript:
  
-speakertext: The call for speakers is open.
+speakertext: The call for speakers is closed.
 speakerlisturl: 
 callforspeakersurl: https://sessionize.com/sqlsaturday-denver-2023/
-callforspeakers:  true
+callforspeakers:  false
 callforspeakersenddate: 2023-05-31 
 
 organizers:


### PR DESCRIPTION
Update to Denver 2023 yaml with Call for Speakers now closed (5/31). Shows text for both that it is open and closed right now.