### PR TITLE
Event 1087 - Fix URL for Sponsor Logo

### DIFF
--- a/_data/events/SQLSat1087.yml
+++ b/_data/events/SQLSat1087.yml
@@ -64,7 +64,7 @@ sponsors:
     height: 340
   - link: https://www.trace3.com/
     type: Silver
-    image: /assets/event/1063/Trace3_Logo.png
+    image: /assets/event/1087/Trace3_Logo.png
     width: 1296
     height: 432
 


### PR DESCRIPTION
The sponsor logo URL accidentally had the wrong event number.