### PR TITLE
New CLE Data Rocks Website

### DIFF
--- a/_data/otherevents.yml
+++ b/_data/otherevents.yml
@@ -46,7 +46,7 @@ events:
 
 - title: "Cleveland Data Rocks 2025 - Ohio"
   date: February 8, 2025
-  url: https://www.meetup.com/ohio-north-database-training/events/301170152/
+  url: https://clevelanddatarocks.com/register/
   thumb: /assets/img/logos/CLEDataRocks.png
 
 - title: "DeveloperWeek"


### PR DESCRIPTION
Change website from Meetup to new Cleveland Data Rocks event registration website.