### PR TITLE
Fix event URLs for Data Saturday events

### DIFF
--- a/_data/otherevents.yml
+++ b/_data/otherevents.yml
@@ -5,7 +5,7 @@ events:
   thumb: /assets/img/logos/vslivelogo.png
 - title: "Data Saturday #86 - Gothenburg 2026"
   date: Sep 5 2026
-  url: https://datasaturdays.com/Event/20260711-datasaturday0084
+  url: https://datasaturdays.com/Event/20260905-datasaturday0086
   thumb: /assets/img/logos/datasaturday_logo.png
 - title: "VSLive! San Diego"
   date: Sep 14-18, 2026
@@ -13,7 +13,7 @@ events:
   thumb: /assets/img/logos/vslivelogo.png
 - title: "Data Saturday #87 - Holland 2026"
   date: Oct 10 2026
-  url: https://datasaturdays.com/Event/20260711-datasaturday0084
+  url: https://datasaturdays.com/Event/20261010-datasaturday0087
   thumb: /assets/img/logos/datasaturday_logo.png
 - title: "PASS Data Community Summit West"
   date: Nov 9-11, 2026


### PR DESCRIPTION
These events were pointing to an old / wrong event, so adjust them to the proper urls. The Gothenburg one is a no brainer, the Holland one is less obvious since there isn't much info on Holland, but it still seems better than pointing to an obviously wrong site.